### PR TITLE
Retry checksum validation reads 3 times in updater tools

### DIFF
--- a/updater/main.c
+++ b/updater/main.c
@@ -17,7 +17,7 @@
 #define DELAY_BETWEEN_SECTORS   12000u
 #define DELAY_BEFORE_FINAL_ACK  4000u
 
-#define MAX_READ_RETRIES        2u
+#define MAX_READ_RETRIES        3u
 
 static void print_hex8(uint8_t v)
 {
@@ -182,7 +182,7 @@ static uint8_t fw_send_sector(uint8_t sector,
     cputs("Write done");
     print_crlf();
 
-    for (attempt = 0; attempt < 2; ++attempt) {
+    for (attempt = 0; attempt < MAX_READ_RETRIES; ++attempt) {
         dev_checksum = fw_read();
 
         cputs("Checksum expected: $");
@@ -197,7 +197,7 @@ static uint8_t fw_send_sector(uint8_t sector,
             break;
         }
 
-        if (attempt == 0) {
+        if (attempt + 1u < MAX_READ_RETRIES) {
             cputs("Retry checksum read...");
             print_crlf();
             delay_loops(DELAY_AFTER_SECTOR_SEL);

--- a/updater_demo/updater_demo.c
+++ b/updater_demo/updater_demo.c
@@ -18,6 +18,8 @@
 #define DELAY_BETWEEN_SECTORS   12000u
 #define DELAY_BEFORE_FINAL_ACK  4000u
 
+#define MAX_READ_RETRIES        3u
+
 static const uint8_t sector_pattern[FW_UPDATE_SECTOR_COUNT] = {
      0xA0, 0xB0, 0xC0//, 0xD0
 };
@@ -197,15 +199,28 @@ static uint8_t fw_send_sector(uint8_t sector, uint8_t base)
     cputs("Write done");
     print_crlf();
 
-    dev_checksum = fw_read();
+    for (attempt = 0; attempt < MAX_READ_RETRIES; ++attempt)
+    {
+        dev_checksum = fw_read();
 
-    cputs("Checksum expected: $");
-    print_hex8(checksum);
-    print_crlf();
+        cputs("Checksum expected: $");
+        print_hex8(checksum);
+        print_crlf();
 
-    cputs("Checksum read:     $");
-    print_hex8(dev_checksum);
-    print_crlf();
+        cputs("Checksum read:     $");
+        print_hex8(dev_checksum);
+        print_crlf();
+
+        if (dev_checksum == checksum) {
+            break;
+        }
+
+        if (attempt + 1u < MAX_READ_RETRIES) {
+            cputs("Retry checksum read...");
+            print_crlf();
+            delay_loops(DELAY_AFTER_SECTOR_SEL);
+        }
+    }
 
     if (dev_checksum != checksum) {
         cputs("ERROR: checksum mismatch");


### PR DESCRIPTION
### Motivation

- Improve robustness of updater checksum validation by performing at least three consecutive reads with delays when the device checksum does not match the expected value, matching the retry pattern used for `FW_UPDATE_START_ACK` handling.

### Description

- Increase `MAX_READ_RETRIES` from `2` to `3` in `updater/main.c` and add the same `#define MAX_READ_RETRIES 3u` to `updater_demo/updater_demo.c`.
- Change the checksum verification loops in both `fw_send_sector` implementations to perform up to `MAX_READ_RETRIES` reads instead of a fixed two attempts.
- Only print the "Retry checksum read..." message and delay when another retry attempt remains (i.e. when `attempt + 1 < MAX_READ_RETRIES`).
- The changes are applied consistently to the updater and the updater demo so both execute the same 3-attempt retry-and-delay behavior.

### Testing

- Ran `make -C updater` to build the updater; the build failed in this environment because the `cl65` toolchain is not installed (automated build failed).
- Ran `make -C updater_demo` to build the updater demo; the build failed in this environment because the `cl65` toolchain is not installed (automated build failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b375b440788323b30a507d1b3e191a)