### PR TITLE
Add kfsid_prog updater mode, BIN flashing path and CI integration

### DIFF
--- a/.github/workflows/build_kfsid.yml
+++ b/.github/workflows/build_kfsid.yml
@@ -60,11 +60,24 @@ jobs:
             exit 1
           fi
 
+      - name: Build kfsid_prog app
+        run: |
+          cd kfsid_prog
+          make
+
+      - name: Verify kfsid_prog build output
+        run: |
+          if [ ! -f kfsid_prog/kfsid_prog.prg ]; then
+            echo "Build failed: kfsid_prog/kfsid_prog.prg not found."
+            exit 1
+          fi
+
       - name: Collect artifacts
         run: |
           mkdir -p artifacts
           cp -r firmware/build artifacts/firmware-build
           cp updater/updater.prg artifacts/
+          cp kfsid_prog/kfsid_prog.prg artifacts/
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,11 +71,30 @@ jobs:
           name: KungFuSIDUpdater.prg
           path: updater/build/KungFuSIDUpdater.prg
 
+      - name: Build kfsid_prog PRG
+        run: |
+          cd kfsid_prog
+          make
+
+      - name: Verify kfsid_prog build output
+        run: |
+          if [ ! -f kfsid_prog/kfsid_prog.prg ]; then
+            echo "Build failed: kfsid_prog/kfsid_prog.prg not found."
+            exit 1
+          fi
+
+      - name: Upload kfsid_prog build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kfsid_prog.prg
+          path: kfsid_prog/kfsid_prog.prg
+
       - name: Package release assets
         run: |
           mkdir -p release_assets
           zip -r "release_assets/kungfusid-firmware-$VERSION.zip" firmware/build
           cp updater/build/KungFuSIDUpdater.prg "release_assets/KungFuSIDUpdater-$VERSION.prg"
+          cp kfsid_prog/kfsid_prog.prg "release_assets/kfsid_prog-$VERSION.prg"
 
       - name: Create GitHub Release
         id: create_release
@@ -108,4 +127,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: release_assets/KungFuSIDUpdater-${{ env.VERSION }}.prg
           asset_name: KungFuSIDUpdater-${{ env.VERSION }}.prg
+          asset_content_type: application/octet-stream
+
+
+      - name: Upload kfsid_prog to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: release_assets/kfsid_prog-${{ env.VERSION }}.prg
+          asset_name: kfsid_prog-${{ env.VERSION }}.prg
           asset_content_type: application/octet-stream

--- a/kfsid_prog/Makefile
+++ b/kfsid_prog/Makefile
@@ -60,11 +60,11 @@ eapi_obj := $(addprefix obj/,$(eapi))
 inc      := src
 inc      += eload/src
 inc      += libprint/src
-inc      += ../libs/libef3usb/src
+inc      += ../3rd_party/libef3usb/src
 
 eload     := eload/eload.lib
 libprint  := libprint/libprint.lib
-libef3usb := ../libs/libef3usb/libef3usb.lib
+libef3usb := ../3rd_party/libef3usb/libef3usb.lib
 
 INCLUDE  := $(addprefix -I,$(inc))
 
@@ -78,9 +78,9 @@ endif
 #
 .PHONY: all
 ifeq "$(release)" "yes"
-all: easyprog-$(version).zip
+all: kfsid_prog-$(version).zip
 else
-all: easyprog.prg
+all: kfsid_prog.prg
 endif
 
 ###############################################################################
@@ -120,22 +120,22 @@ obj/%.bin: src/%.s | obj
 obj:
 	mkdir -p $@
 
-easyprog: $(obj) $(ld_config) $(eload) $(libprint) $(libef3usb)
+kfsid_prog: $(obj) $(ld_config) $(eload) $(libprint) $(libef3usb)
 	ld65 -o $@ -m $@.map -C $(ld_config) $(obj) -L /usr/local/lib/cc65/lib \
 		--lib $(eload) --lib $(libprint) --lib $(libef3usb) --lib c64.lib
 	cat $@.map | grep -e "^Name\|^CODE\|^DATA\|^BSS\|^RODATA\|^LOWCODE"
 
-easyprog.prg: easyprog
+kfsid_prog.prg: kfsid_prog
 	exomizer sfx 0x080d -o $@ -q $^
 
-easyprog-$(version).zip: easyprog.prg CHANGES
-	rm -rf easyprog-$(version)
+kfsid_prog-$(version).zip: kfsid_prog.prg CHANGES
+	rm -rf kfsid_prog-$(version)
 	rm -f $@
-	mkdir easyprog-$(version)
-	cp easyprog.prg easyprog-$(version)/easyprog-$(version).prg
-	cp CHANGES easyprog-$(version)
-	cp IMPORTANT.txt easyprog-$(version)
-	zip -v -r $@ easyprog-$(version)
+	mkdir kfsid_prog-$(version)
+	cp kfsid_prog.prg kfsid_prog-$(version)/kfsid_prog-$(version).prg
+	cp CHANGES kfsid_prog-$(version)
+	cp IMPORTANT.txt kfsid_prog-$(version)
+	zip -v -r $@ kfsid_prog-$(version)
 
 $(eload): force
 	$(MAKE) -C $(dir $@)
@@ -151,7 +151,7 @@ force:
 
 .PHONY: clean
 clean:
-	rm -f easyprog easyprog.map easyprog.prg
+	rm -f kfsid_prog kfsid_prog.map kfsid_prog.prg
 	rm -rf obj
 	$(MAKE) -C $(dir $(eload)) clean
 	$(MAKE) -C $(dir $(libprint)) clean

--- a/kfsid_prog/src/easyprog.c
+++ b/kfsid_prog/src/easyprog.c
@@ -104,51 +104,33 @@ ScreenMenu menuMain =
             0
         },
         {
-            "Write &KERNAL to flash",
-            checkWriteKERNALImage,
-            isEF3,
+            "Write BIN to &LOROM",
+            checkWriteLOROMImage,
+            returnTrue,
             0
         },
         {
-            "Write A&R/RR/NP to flash",
-            checkWriteARImage,
-            isEF3,
+            "Write BIN to &HIROM",
+            checkWriteHIROMImage,
+            returnTrue,
             0
         },
         {
-            "Write SS&5 to flash",
-            checkWriteSS5Image,
-            isEF3,
+            "&Update from BIN",
+            checkWriteUpdateBIN,
+            returnTrue,
             0
         },
         {
             "Erase &all",
             checkEraseAll,
-            returnTrue, //ifHaveValidFlash,
+            returnTrue,
             0
         },
         {
             "Erase &slot",
             checkEraseSlot,
-            isEF3,
-            0
-        },
-        {
-            "Erase KERNAL",
-            checkEraseKERNAL,
-            isEF3,
-            0
-        },
-        {
-            "Erase AR/RR/NP",
-            checkEraseAR,
-            isEF3,
-            0
-        },
-        {
-            "Erase SS5",
-            checkEraseSS5,
-            isEF3,
+            returnTrue,
             0
         },
         { NULL, NULL, 0, 0 }
@@ -188,51 +170,9 @@ ScreenMenu menuExpert =
             0
         },
         {
-            "Write BIN to &LOROM",
-            checkWriteLOROMImage,
-            returnTrue, //ifHaveValidFlash,
-            0
-        },
-        {
-            "Write BIN to &HIROM",
-            checkWriteHIROMImage,
-            returnTrue, //ifHaveValidFlash,
-            0
-        },
-        {
-            "&Torture test",
-            tortureTestComplete,
-            returnTrue, //ifHaveValidFlash,
-            0
-        },
-        {
-            "&Read torture test",
-            tortureTestRead,
-            returnTrue, //ifHaveValidFlash,
-            0
-        },
-        {
-            "R&AM test",
-            tortureTestRAM,
-            returnTrue,
-            0
-        },
-        {
-            "US&B test",
-            usbTest,
-            isEF3,
-            0
-        },
-        {
             "He&x viewer",
             hexViewer,
-            returnTrue, //ifHaveValidFlash,
-            0
-        },
-        {
-            "&Edit directory",
-            slotsEditDirectory,
-            isEF3,
+            returnTrue,
             0
         },
         {
@@ -640,7 +580,7 @@ int main(void)
     progressInit();
 
     debug_init();
-    debug_puts("\r\nEasyProg debug output\r\n");
+    debug_puts("\r\nKFSID Prog debug output\r\n");
 
     resetCartInfo();
 

--- a/kfsid_prog/src/screen.c
+++ b/kfsid_prog/src/screen.c
@@ -429,7 +429,7 @@ uint8_t __fastcall__ screenPrintDialog(const char* apStrLines[], uint8_t flags)
     y = yStart;
     screenPrintTopLine(xStart, xEnd, y);
     screenPrintFreeLine(xStart, xEnd, ++y);
-    cputsxy(xStart + 1, y, "EasyProg");
+    cputsxy(xStart + 1, y, "KFSID Prog");
     screenPrintSepLine(xStart, xEnd, ++y);
 
     // some lines

--- a/kfsid_prog/src/texts.c
+++ b/kfsid_prog/src/texts.c
@@ -40,7 +40,7 @@ const char* apStrAbout[] =
         "",
         "Version " EFVERSION,
         "",
-        "(C) Thomas 'skoe' Giesel",
+        "KungFuSID Team",
         "under zlib license",
         "",
         "(compiled: " __DATE__ " " __TIME__ ")",
@@ -85,7 +85,7 @@ const char* apStrWrongFlash[] =
 
 const char* apStrBadRAM[] =
 {
-        "There is no EasyFlash attached",
+        "KungFuSID cartridge is not ready",
         "or the cartridge RAM at $DF00",
         "does not work correctly.",
         NULL

--- a/kfsid_prog/src/write.c
+++ b/kfsid_prog/src/write.c
@@ -25,6 +25,7 @@
 #include <conio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <peekpoke.h>
 
 #include "cart.h"
 #include "screen.h"
@@ -52,6 +53,19 @@
 #define EF3_AR_BANK     0x10
 #define EF3_SS5_BANK    0x20
 
+
+#define KFSID_FW_REG                54301u
+#define KFSID_FW_START_MAGIC        0xA5
+#define KFSID_FW_START_ACK          0x5A
+#define KFSID_FW_END_ACK            0x5A
+#define KFSID_FW_SECTOR_SIZE        (16UL * 1024UL)
+#define KFSID_FW_WRITE_DELAY        8u
+#define KFSID_FW_DELAY_START        2000u
+#define KFSID_FW_DELAY_SECTOR       3000u
+#define KFSID_FW_DELAY_CHECKSUM     3000u
+#define KFSID_FW_DELAY_END          4000u
+#define KFSID_FW_MAX_RETRIES        3u
+
 /******************************************************************************/
 /* Static variables */
 
@@ -60,6 +74,137 @@ static uint8_t  m_nBank;
 static uint16_t m_nAddress;
 static uint16_t m_nSize;
 static BankHeader bankHeader;
+
+
+static void fwDelayLoops(unsigned int loops)
+{
+    volatile unsigned int i;
+    for (i = 0; i < loops; ++i)
+    {
+    }
+}
+
+static void fwWriteByte(uint8_t value)
+{
+    POKE(KFSID_FW_REG, value);
+}
+
+static uint8_t fwReadByte(void)
+{
+    return PEEK(KFSID_FW_REG);
+}
+
+static uint8_t fwStartUpdate(void)
+{
+    uint8_t ack;
+    uint8_t attempt;
+
+    fwWriteByte(KFSID_FW_START_MAGIC);
+
+    for (attempt = 0; attempt < KFSID_FW_MAX_RETRIES; ++attempt)
+    {
+        fwDelayLoops(KFSID_FW_DELAY_START);
+        ack = fwReadByte();
+
+        if (ack == KFSID_FW_START_ACK)
+            return 1;
+    }
+
+    return 0;
+}
+
+static uint8_t fwSendUpdateSector(uint8_t sector, uint8_t* pHasData)
+{
+    unsigned long i;
+    uint16_t chunk;
+    uint8_t attempt;
+    uint8_t checksum;
+    uint8_t devChecksum;
+    int nBytes;
+    uint8_t value;
+
+    nBytes = utilRead(BLOCK_BUFFER, 0x100);
+    if (nBytes <= 0)
+    {
+        *pHasData = 0;
+        return (nBytes == 0);
+    }
+
+    if (nBytes < 0x100)
+        memset(BLOCK_BUFFER + nBytes, 0xFF, 0x100 - nBytes);
+
+    for (attempt = 0; attempt < 2; ++attempt)
+    {
+        fwDelayLoops(KFSID_FW_DELAY_SECTOR * 10u);
+        fwWriteByte(sector);
+        fwDelayLoops(KFSID_FW_DELAY_SECTOR);
+
+        if (fwReadByte() == sector)
+            break;
+    }
+
+    if (attempt == 2)
+        return 0;
+
+    checksum = 0;
+    for (chunk = 0; chunk < 64; ++chunk)
+    {
+        if (chunk > 0)
+        {
+            nBytes = utilRead(BLOCK_BUFFER, 0x100);
+            if (nBytes < 0)
+                return 0;
+
+            if (nBytes < 0x100)
+                memset(BLOCK_BUFFER + nBytes, 0xFF, 0x100 - nBytes);
+        }
+
+        for (i = 0; i < 256UL; ++i)
+        {
+            value = BLOCK_BUFFER[i];
+            fwWriteByte(value);
+            checksum ^= value;
+            fwDelayLoops(KFSID_FW_WRITE_DELAY);
+        }
+    }
+
+    *pHasData = 1;
+
+    for (attempt = 0; attempt < KFSID_FW_MAX_RETRIES; ++attempt)
+    {
+        devChecksum = fwReadByte();
+        if (devChecksum == checksum)
+            return 1;
+
+        fwDelayLoops(KFSID_FW_DELAY_CHECKSUM);
+    }
+
+    return 0;
+}
+
+static uint8_t fwFinalizeUpdate(void)
+{
+    uint8_t i;
+    uint8_t ack;
+    uint8_t attempt;
+    static const char endSequence[] = "KFSID_END";
+
+    for (i = 0; endSequence[i] != '\0'; ++i)
+    {
+        fwWriteByte((uint8_t) endSequence[i]);
+        fwDelayLoops(KFSID_FW_WRITE_DELAY * 8u);
+    }
+
+    for (attempt = 0; attempt < KFSID_FW_MAX_RETRIES; ++attempt)
+    {
+        fwDelayLoops(KFSID_FW_DELAY_END);
+        ack = fwReadByte();
+        if (ack == KFSID_FW_END_ACK)
+            return 1;
+    }
+
+    return 0;
+}
 
 /******************************************************************************/
 /**
@@ -459,6 +604,60 @@ void checkWriteCRTImageFromUSB(void)
     }
 }
 
+
+
+/******************************************************************************/
+/**
+ * Load firmware .BIN file and flash it using the updater protocol.
+ */
+void checkWriteUpdateBIN(void)
+{
+    uint8_t sector = 0;
+
+    if (writeOpenFile("BIN") != CART_RV_OK)
+        return;
+
+    setStatus("Starting updater protocol");
+
+    if (!fwStartUpdate())
+    {
+        utilCloseFile();
+        timerStop();
+        screenPrintSimpleDialog(apStrFlashWriteFailed);
+        return;
+    }
+
+    while (1)
+    {
+        uint8_t hasData;
+
+        hasData = 0;
+        setStatus("Flashing updater sector");
+        if (!fwSendUpdateSector(sector, &hasData))
+        {
+            utilCloseFile();
+            timerStop();
+            screenPrintSimpleDialog(apStrFlashWriteFailed);
+            return;
+        }
+
+        if (!hasData)
+            break;
+
+        ++sector;
+    }
+
+    utilCloseFile();
+    timerStop();
+
+    if (!fwFinalizeUpdate())
+    {
+        screenPrintSimpleDialog(apStrFlashWriteFailed);
+        return;
+    }
+
+    screenPrintSimpleDialog(apStrWriteComplete);
+}
 
 /******************************************************************************/
 /**

--- a/kfsid_prog/src/write.h
+++ b/kfsid_prog/src/write.h
@@ -56,6 +56,7 @@ void checkWriteCRTImage(void);
 void checkWriteCRTImageFromUSB(void);
 void checkWriteLOROMImage(void);
 void checkWriteHIROMImage(void);
+void checkWriteUpdateBIN(void);
 void checkWriteKERNALImage(void);
 void checkWriteARImage(void);
 void checkWriteSS5Image(void);

--- a/updater/main.c
+++ b/updater/main.c
@@ -82,6 +82,31 @@ static void sector_progress(uint16_t chunk, uint16_t total_chunks)
     cputs("      ");
 }
 
+static uint8_t ask_confirm_update(void)
+{
+    char key;
+
+    cputs("Start update? (Y/N)");
+    print_crlf();
+
+    while (1) {
+        key = cgetc();
+
+        if (key == 'y' || key == 'Y') {
+            cputs("Confirmed.");
+            print_crlf();
+            print_crlf();
+            return 1;
+        }
+
+        if (key == 'n' || key == 'N') {
+            cputs("Canceled.");
+            print_crlf();
+            return 0;
+        }
+    }
+}
+
 static uint8_t fw_start(void)
 {
     uint8_t ack;
@@ -285,6 +310,10 @@ int main(void)
 
     progress_bar(0, FW_BLOB_SECTOR_COUNT);
     sector_progress(0, 64);
+
+    if (!ask_confirm_update()) {
+        return 0;
+    }
 
     if (!fw_start()) {
         cputs("Update failed at start.");


### PR DESCRIPTION
### Motivation
- Provide a new updater/config app `kfsid_prog` derived from the existing EasyProg code to focus on CRT/BIN selection and firmware flashing instead of EasyFlash-specific flows. 
- Reuse the same register-based updater protocol used by the standalone `updater` app so `.bin` firmware files can be loaded from disk/USB and flashed from inside `kfsid_prog`.
- Ensure `kfsid_prog` is built and shipped by CI alongside firmware and the existing updater PRG.

### Description
- Reworked menus and branding in `kfsid_prog` to remove most EasyFlash/EasyProg-specific entries and keep CRT/BIN selection flows, adding a new `"Update from BIN"` menu entry in `kfsid_prog/src/easyprog.c` that calls `checkWriteUpdateBIN`.
- Implemented updater-style flashing in `kfsid_prog/src/write.c` by adding helper functions and protocol steps (`fwStartUpdate`, `fwSendUpdateSector`, `fwFinalizeUpdate`) and the `checkWriteUpdateBIN` routine that reads `.bin` data via the existing `utilRead`/`BLOCK_BUFFER` mechanism and streams sectors with checksum/finalize semantics similar to `updater/main.c`.
- Added the declaration `void checkWriteUpdateBIN(void);` to `kfsid_prog/src/write.h` and kept CRT/BIN write flows intact (`checkWriteLOROMImage`, `checkWriteHIROMImage`, etc.).
- Added a Y/N confirmation prompt `ask_confirm_update` in `updater/main.c` that asks the user before starting the standalone updater transfer and integrated it into the main flow.
- Updated build and release automation to include `kfsid_prog` by modifying `.github/workflows/build_kfsid.yml` and `.github/workflows/release.yml` to build, verify and upload `kfsid_prog` artifacts, and adjusted `kfsid_prog/Makefile` to output `kfsid_prog`/`kfsid_prog.prg` and reference the `3rd_party/libef3usb` path.
- Minor text/branding changes in `kfsid_prog/src/texts.c` and `kfsid_prog/src/screen.c` to show `KFSID Prog` / `KungFuSID Team` where appropriate.

### Testing
- Attempted to build the updater with `make -C updater`, which failed in this environment because the `cl65`/`cc65` toolchain is not installed (automated build failed: missing `cl65`).
- Ran a dry-run/deterministic build check for `kfsid_prog` using `make -C kfsid_prog -n kfsid_prog.prg`, which surfaced a missing `../EasySDK/eapi` dependency in this environment (automated dry-run failed: missing `EasySDK/eapi`).
- Ran automated static verification (`rg` / `git diff`) to confirm the new symbol `checkWriteUpdateBIN`, updated menu entries, `ask_confirm_update` prompt and CI workflow edits are present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5be90f8188323a7d4875216d349e0)