### PR TITLE
Fix kfsid_prog linker config unresolved __MAIN_* symbols

### DIFF
--- a/kfsid_prog/src/ld2.cfg
+++ b/kfsid_prog/src/ld2.cfg
@@ -1,6 +1,8 @@
 
 SYMBOLS {
     __STACKSIZE__: type = weak, value = $0800;
+    __MAIN_START__: type = weak, value = __RAM_START__;
+    __MAIN_SIZE__: type = weak, value = __RAM_SIZE__;
 }
 
 MEMORY {


### PR DESCRIPTION
### Motivation
- Resolve linker failures where `c64/crt0.s` references unresolved externals `__MAIN_START__` and `__MAIN_SIZE__` when linking with newer `ld65`.

### Description
- Add weak linker symbols to `kfsid_prog/src/ld2.cfg`: `__MAIN_START__` mapped to `__RAM_START__` and `__MAIN_SIZE__` mapped to `__RAM_SIZE__`, so the runtime startup symbols are provided.

### Testing
- Ran `make -C kfsid_prog kfsid_prog -j1`, which aborted early because `acme` is not installed in this environment, so a full build/link verification could not be completed here; the linker-symbol fix addresses the previously reported `ld65` unresolved externals.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b70317e94483238fd8be5fb4ae7fec)